### PR TITLE
Remove unnecessary characters

### DIFF
--- a/examples/default_vpc/outputs.tf
+++ b/examples/default_vpc/outputs.tf
@@ -1,24 +1,24 @@
 output "id" {
-  value       = "${module.example.id}"
+  value       = module.example.id
   description = "The EC2 instance ID"
 }
 
 output "arn" {
-  value       = "${module.example.arn}"
+  value       = module.example.arn
   description = "The EC2 instance ARN"
 }
 
 output "availability_zone" {
-  value       = "${module.example.availability_zone}"
+  value       = module.example.availability_zone
   description = "The AZ where the EC2 instance is deployed"
 }
 
 output "private_ip" {
-  value       = "${module.example.private_ip}"
+  value       = module.example.private_ip
   description = "The private IP of the EC2 instance"
 }
 
 output "subnet_id" {
-  value       = "${module.example.subnet_id}"
+  value       = module.example.subnet_id
   description = "The ID of the subnet where the EC2 instance is deployed"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,24 @@
 output "id" {
-  value       = "${aws_instance.example.id}"
+  value       = aws_instance.example.id
   description = "The EC2 instance ID"
 }
 
 output "arn" {
-  value       = "${aws_instance.example.arn}"
+  value       = aws_instance.example.arn
   description = "The EC2 instance ARN"
 }
 
 output "availability_zone" {
-  value       = "${aws_instance.example.availability_zone}"
+  value       = aws_instance.example.availability_zone
   description = "The AZ where the EC2 instance is deployed"
 }
 
 output "private_ip" {
-  value       = "${aws_instance.example.private_ip}"
+  value       = aws_instance.example.private_ip
   description = "The private IP of the EC2 instance"
 }
 
 output "subnet_id" {
-  value       = "${aws_instance.example.subnet_id}"
+  value       = aws_instance.example.subnet_id
   description = "The ID of the subnet where the EC2 instance is deployed"
 }


### PR DESCRIPTION
When defining the outputs, there is no need to use quotes, braces, or dollar signs when referencing variables.