### PR TITLE
Fix broken terraform-docs install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.8'
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2-beta
         with:
           go-version: '1.13.8'
       - name: Cache pip test requirements


### PR DESCRIPTION
## 🗣 Description

In this pull request we add the [`setup-go`](https://github.com/actions/setup-go) action to specify the version of go to use.  This is required to get around the fact that terraform-docs does not install with the version of go that is present by default.

## 💭 Motivation and Context

Without this change, all GitHub Actions that are triggered by this repository or any cloned from it fail.  Bad news.

## 🧪 Testing

I committed these changes and verified that the GitHub Actions that are triggered now pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
