### PR TITLE
Remove GitHub Actions Caching for the '.terraform' Directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ env:
   PIP_CACHE_DIR: ~/.cache/pip
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
-  TF_CACHE_DIR: .terraform
 
 jobs:
   lint:
@@ -61,11 +60,6 @@ jobs:
         with:
           path: ${{ steps.go-cache.outputs.dir }}
           key: "${{ runner.os }}-go"
-      - name: Cache Terraform initialization
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.TF_CACHE_DIR }}
-          key: "${{ runner.os }}-terraform-initialization"
       - name: Install Terraform
         run: |
           mkdir -p ${{ env.CURL_CACHE_DIR }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
             | sort -u) ]]; do \
+            echo "Initializing '$path'..." \
             terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           for path in $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
             | sort -u); do \
-            echo "Initializing '$path'...\n" \
+            echo "Initializing '$path'..."; \
             terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,9 @@ jobs:
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs
       - name: Find and initialize Terraform directories
         run: |
-          for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
-            | sort -u) ]]; do \
-            echo "Initializing '$path'..." \
+          for path in $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
+            | sort -u); do \
+            echo "Initializing '$path'...\n" \
             terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR removes caching for the `.terraform` directory in our GitHub Actions workflow. It also adds some informative output to the loop that initialized directories containing Terraform code.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
When I originally added caching of the `.terraform` directory it was with the goal of reducing wait time for downloading providers. Not long after that the `terraform init` call was modified to include the `-upgrade=true` switch. When this switch is provided, Terraform will download the latest version of the needed providers no matter what version is installed. This negates the original intent behind caching the `.terraform` directory and makes the caching both pointless and possibly problematic if GitHub is incorrectly restoring a cached `.terraform` directory.

I noticed when looking at a more complicated Terraform initialization that there was no indication for what path was being used for the `terraform init` call. This makes debugging troublesome so I added an `echo` statement to the Terraform initialization loop to give a clear indication of what is being attempted.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
Automated testing passes locally and in GitHub Actions.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
