### PR TITLE
Pin AWS Terraform provider to the major version we are currently using

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,10 @@
-
 terraform {
   required_version = ">= 0.12"
+
+  # If you use any other providers you should also pin them to the
+  # major version currently being used.  This practice will help us
+  # avoid unwelcome surprises.
+  required_providers {
+    aws = "~> 2.0"
+  }
 }


### PR DESCRIPTION
## 🗣 Description

This pull request pins the AWS Terraform provider to the major version we are currently using.

## 💭 Motivation and Context

This is a bugfix because version 3 of the AWS provider was recently rolled out, and we want to avoid it since it is a hot mess right now.  For instance, version 3 cannot currently be used to deploy any Terraform code that involves EC2 instances because of terraform-providers/terraform-provider-aws#14431.

Projects that inherit from this skeleton should pin any other providers they use to the major version currently in use.  This is a good practice since it will help us avoid unwelcome surprises in the future.

## 🧪 Testing

All pre-commit hooks pass.  The same change was made in cisagov/cool-assessment-terraform#62, and that code was successfully used to deploy to env1 in our COOL staging envcironment.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
