### PR TITLE
Restrict TF to the 0.12 releases for now

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 0.12"
+  # We want to hold off on 0.13 until we have tested it.
+  required_version = "~> 0.12.0"
 
   # If you use any other providers you should also pin them to the
   # major version currently being used.  This practice will help us


### PR DESCRIPTION
## 🗣 Description

This pull request restricts TF to the 0.12 releases for now.

## 💭 Motivation and Context

We don't want to jump into 0.13 until we have tested it.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
