### PR TITLE
Fix another old-style set-output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,7 @@ jobs:
           "$(go version | sed 's/^go version go\([0-9.]\+\) .*/\1/')" \
           >> $GITHUB_ENV
       - name: Lookup go cache directory
-        id: go-cache
-        run: |
-          echo "::set-output name=dir::$(go env GOCACHE)"
+        run: echo "GOCACHE_DIR=$(go env GOCACHE)" >> $GITHUB_ENV
       - name: Cache linting environments
         uses: actions/cache@v2
         with:
@@ -52,7 +50,7 @@ jobs:
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.PRE_COMMIT_CACHE_DIR }}
             ${{ env.CURL_CACHE_DIR }}
-            ${{ steps.go-cache.outputs.dir }}
+            ${{ env.GOCACHE_DIR }}
           key: "lint-${{ runner.os }}-\
             py${{ env.PY_VERSION }}-\
             go${{ env.GO_VERSION }}-\


### PR DESCRIPTION
## 🗣 Description

This pull request changes an old-style `set-output` to instead use `$GITHUB_ENV`.

## 💭 Motivation and Context

We now prefer the use of `$GITHUB_ENV` to this old way of doing things.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
