### PR TITLE
Use Go 1.16 in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: 3.9
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: '1.16'
       - name: Store installed Go version
         run: |
           echo "GO_VERSION="\


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Update the version of Go installed in the GitHub Actions workflow to use Go 1.16.

## 💭 Motivation and context ##

The latest release of [terraform-docs](https://github.com/terraform-docs/terraform-docs) requires Go 1.16 and GHA runs that use it currently fail on 1.15 as documented in https://github.com/cisagov/skeleton-ansible-role-with-test-user/issues/16.

## 🧪 Testing ##

GitHub Actions `lint` job runs without issue with this change in place.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
