### PR TITLE
Use the AWS provider's default tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ module "example" {
   aws_region            = "us-west-1"
   aws_availability_zone = "b"
   subnet_id             = "subnet-0123456789abcdef0"
-
-  tags = {
-    Key1 = "Value1"
-    Key2 = "Value2"
-  }
 }
 ```
 
@@ -40,13 +35,13 @@ module "example" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 3.0 |
+| aws | ~> 3.38 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | ~> 3.38 |
 
 ## Modules ##
 
@@ -67,7 +62,6 @@ No modules.
 | aws\_availability\_zone | The AWS availability zone to deploy into (e.g. a, b, c, etc.). | `string` | `"a"` | no |
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
 | subnet\_id | The ID of the AWS subnet to deploy into (e.g. subnet-0123456789abcdef0). | `string` | n/a | yes |
-| tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
 ## Outputs ##
 

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -38,6 +38,7 @@ No requirements.
 | ami\_owner\_account\_id | The ID of the AWS account that owns the AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `"self"` | no |
 | aws\_availability\_zone | The AWS availability zone to deploy into (e.g. a, b, c, etc.). | `string` | `"a"` | no |
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
+| tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
 | tf\_role\_arn | The ARN of the role that can terraform non-specialized resources. | `string` | n/a | yes |
 
 ## Outputs ##

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -38,7 +38,7 @@ No requirements.
 | ami\_owner\_account\_id | The ID of the AWS account that owns the AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `"self"` | no |
 | aws\_availability\_zone | The AWS availability zone to deploy into (e.g. a, b, c, etc.). | `string` | `"a"` | no |
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
-| tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
+| tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | tf\_role\_arn | The ARN of the role that can terraform non-specialized resources. | `string` | n/a | yes |
 
 ## Outputs ##

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -1,10 +1,11 @@
 provider "aws" {
   # Our primary provider uses our terraform role
-  region = var.aws_region
   assume_role {
     role_arn     = var.tf_role_arn
     session_name = "terraform-example"
   }
+  default_tags = var.tags
+  region       = var.aws_region
 }
 
 #-------------------------------------------------------------------------------

--- a/examples/basic_usage/variables.tf
+++ b/examples/basic_usage/variables.tf
@@ -35,6 +35,6 @@ variable "aws_region" {
 
 variable "tags" {
   type        = map(string)
-  description = "Tags to apply to all AWS resources created"
+  description = "Tags to apply to all AWS resources created."
   default     = {}
 }

--- a/examples/basic_usage/variables.tf
+++ b/examples/basic_usage/variables.tf
@@ -32,3 +32,9 @@ variable "aws_region" {
   description = "The AWS region to deploy into (e.g. us-east-1)."
   default     = "us-east-1"
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to all AWS resources created"
+  default     = {}
+}

--- a/main.tf
+++ b/main.tf
@@ -41,14 +41,16 @@ resource "aws_instance" "example" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
   subnet_id         = var.subnet_id
 
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "Example"
-    },
-  )
+  # The tag or tags specified here will be merged with the provider's
+  # default tags.
+  tags = {
+    "Name" = "Example"
+  }
+  # volume_tags does not yet inherit the default tags from the
+  # provider.  See hashicorp/terraform-provider-aws#19188 for more
+  # details.
   volume_tags = merge(
-    var.tags,
+    provider.aws.default_tags,
     {
       "Name" = "Example"
     },

--- a/variables.tf
+++ b/variables.tf
@@ -31,9 +31,3 @@ variable "aws_region" {
   description = "The AWS region to deploy into (e.g. us-east-1)."
   default     = "us-east-1"
 }
-
-variable "tags" {
-  type        = map(string)
-  description = "Tags to apply to all AWS resources created."
-  default     = {}
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,11 +1,14 @@
 terraform {
-  # We want to hold off on 0.13 until we have tested it.
+  # We want to hold off on 0.13 or higher until we have tested it.
   required_version = "~> 0.12.0"
 
   # If you use any other providers you should also pin them to the
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 3.0"
+    # Version 3.38.0 of the Terraform AWS provider is the first
+    # version to support default tags.
+    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    aws = "~> 3.38"
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes the Terraform module to make use of the default tags from the AWS provider instead of requiring a set of default tags to be passed in as an input variable.

## 💭 Motivation and context ##

This is simpler and cleaner, and is now the preferred mechanism for passing default tags.

## 🧪 Testing ##

I verified that `terraform init -upgrade=true` ran successfully with these changes. 

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
