### PR TITLE
Fix default_tags syntax in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ No modules.
 |------|------|
 | [aws_instance.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_ami.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_default_tags.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 
 ## Inputs ##
 

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -38,7 +38,7 @@ No requirements.
 | ami\_owner\_account\_id | The ID of the AWS account that owns the AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `"self"` | no |
 | aws\_availability\_zone | The AWS availability zone to deploy into (e.g. a, b, c, etc.). | `string` | `"a"` | no |
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
-| tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
+| tags | Tags to apply to all AWS resources created. | `map(string)` | `{"Testing": true}` | no |
 | tf\_role\_arn | The ARN of the role that can terraform non-specialized resources. | `string` | n/a | yes |
 
 ## Outputs ##

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -4,8 +4,10 @@ provider "aws" {
     role_arn     = var.tf_role_arn
     session_name = "terraform-example"
   }
-  default_tags = var.tags
-  region       = var.aws_region
+  default_tags {
+    tags = var.tags
+  }
+  region = var.aws_region
 }
 
 #-------------------------------------------------------------------------------

--- a/examples/basic_usage/variables.tf
+++ b/examples/basic_usage/variables.tf
@@ -36,5 +36,7 @@ variable "aws_region" {
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created."
-  default     = {}
+  default = {
+    Testing = true
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,9 @@ data "aws_ami" "example" {
   most_recent = true
 }
 
+# The default tags configured for the default provider
+data "aws_default_tags" "default" {}
+
 # The example EC2 instance
 resource "aws_instance" "example" {
   ami               = data.aws_ami.example.id
@@ -50,7 +53,7 @@ resource "aws_instance" "example" {
   # provider.  See hashicorp/terraform-provider-aws#19188 for more
   # details.
   volume_tags = merge(
-    provider.aws.default_tags,
+    data.aws_default_tags.default.tags,
     {
       "Name" = "Example"
     },


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
* Fixes some incorrect syntax in the `example/basic_usage` code where the `default_tags` are set.
* Fixes some incorrect syntax in the module code where the default tags of the provider are referenced.
* Adds a tag to the default value of `var.tags` in the `example/basic_usage` code to make it easier to test that the AWS provider `default_tags` are set.

## 💭 Motivation and context ##

See [here](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider) for examples of proper usage.

If this example is not correct then the errors will percolate through time and space.  I don't need that kind of bad karma.

## 🧪 Testing ##

I was able to `terraform apply` with the `example/basic_usage` code and verify that it _would have_ created resources with the correct tags:

```console
$ AWS_SHARED_CREDENTIALS_FILE=~/.aws/staging_credentials AWS_DEFAULT_REGION=us-east-1 ~/bin/terraform init -upgrade=true
Upgrading modules...
- example in ../..

Initializing the backend...

Initializing provider plugins...
- Checking for available provider plugins...
- Downloading plugin for provider "aws" (hashicorp/aws) 3.43.0...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

$ AWS_PROFILE=cool-user AWS_SHARED_CREDENTIALS_FILE=~/.aws/staging_credentials AWS_DEFAULT_REGION=us-east-1 ~/bin/terraform apply -var "tf_role_arn=arn:aws:iam::<COOL staging Images account ID>:role/<role name>"
module.example.data.aws_default_tags.default: Refreshing state...
module.example.data.aws_ami.example: Refreshing state...

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_subnet.example will be created
  + resource "aws_subnet" "example" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "us-east-1a"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.230.0.0/28"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Name" = "Example"
        }
      + tags_all                        = {
          + "Name"    = "Example"
          + "Testing" = "true"
        }
      + vpc_id                          = (known after apply)
    }

  # aws_vpc.example will be created
  + resource "aws_vpc" "example" {
      + arn                              = (known after apply)
      + assign_generated_ipv6_cidr_block = false
      + cidr_block                       = "10.230.0.0/24"
      + default_network_acl_id           = (known after apply)
      + default_route_table_id           = (known after apply)
      + default_security_group_id        = (known after apply)
      + dhcp_options_id                  = (known after apply)
      + enable_classiclink               = (known after apply)
      + enable_classiclink_dns_support   = (known after apply)
      + enable_dns_hostnames             = true
      + enable_dns_support               = true
      + id                               = (known after apply)
      + instance_tenancy                 = "default"
      + ipv6_association_id              = (known after apply)
      + ipv6_cidr_block                  = (known after apply)
      + main_route_table_id              = (known after apply)
      + owner_id                         = (known after apply)
      + tags                             = {
          + "Name" = "Example"
        }
      + tags_all                         = {
          + "Name"    = "Example"
          + "Testing" = "true"
        }
    }

  # module.example.aws_instance.example will be created
  + resource "aws_instance" "example" {
      + ami                                  = "ami-0465265f3f274bf8f"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = (known after apply)
      + availability_zone                    = "us-east-1a"
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t3.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Name" = "Example"
        }
      + tags_all                             = {
          + "Name"    = "Example"
          + "Testing" = "true"
        }
      + tenancy                              = (known after apply)
      + volume_tags                          = {
          + "Name"    = "Example"
          + "Testing" = "true"
        }
      + vpc_security_group_ids               = (known after apply)

      + capacity_reservation_specification {
          + capacity_reservation_preference = (known after apply)

          + capacity_reservation_target {
              + capacity_reservation_id = (known after apply)
            }
        }

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + enclave_options {
          + enabled = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_interface_id  = (known after apply)
        }

      + root_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: no

Apply cancelled.
```

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
