### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ module "example" {
 
 ## Examples ##
 
-- [Deploying into the default VPC](https://github.com/cisagov/skeleton-tf-module/tree/develop/examples/default_vpc)
+- [Basic usage](https://github.com/cisagov/skeleton-tf-module/tree/develop/examples/basic_usage)
 
 ## Requirements ##
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a typo in `README.md` that was pointed out in #54.

## 💭 Motivation and context ##

Resolves #54.

## 🧪 Testing ##

All `pre-commit` hooks pass.  I also went [here](https://github.com/cisagov/skeleton-tf-module/tree/bugfix/fix-broken-documentation) and verified that the link now points to the correct place.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
