### PR TITLE
Support Terraform 1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: cisagov/setup-env-github-action@develop
+      - uses: cisagov/setup-env-github-action@improvement/support_tf_1.0
       - uses: actions/checkout@v2
       - id: setup-python
         uses: actions/setup-python@v2

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ module "example" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.14.0 |
+| terraform | ~> 1.0 |
 | aws | ~> 3.38 |
 
 ## Providers ##

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -12,7 +12,8 @@ Note that this example may create resources which cost money. Run
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.14.0 |
+| terraform | ~> 1.0 |
+| aws | ~> 3.38 |
 
 ## Providers ##
 

--- a/examples/basic_usage/versions.tf
+++ b/examples/basic_usage/versions.tf
@@ -1,6 +1,6 @@
 terraform {
-  # We want to hold off on 1.0 or higher until we have tested it.
-  required_version = "~> 0.14.0"
+  # We want to hold off on 1.1 or higher until we have tested it.
+  required_version = "~> 1.0"
 
   # If you use any other providers you should also pin them to the
   # major version currently being used.  This practice will help us

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,0 @@
-# Default provider information.
-provider "aws" {
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 terraform {
-  # We want to hold off on 1.0 or higher until we have tested it.
-  required_version = "~> 0.14.0"
+  # We want to hold off on 1.1 or higher until we have tested it.
+  required_version = "~> 1.0"
 
   # If you use any other providers you should also pin them to the
   # major version currently being used.  This practice will help us


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR moves this skeleton from Terraform 0.14 to 1.0.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is the last step in our journey of migrating Terraform to a current 1.0.x version. We previously upgraded from Terraform 0.12 to 0.13 with #57 and from 0.13 to 0.14 with #62.

This PR is a part of cisagov/cool-system#219 and related to cisagov/setup-env-github-action#41.

This PR is similar to cisagov/skeleton-packer#89 and cisagov/skeleton-ansible-role-with-test-user#29.

When all testing has been completed with Terraform 1.0 and cisagov/setup-env-github-action#41 has been merged, https://github.com/cisagov/skeleton-tf-module/commit/fd95721232ba242516a4c5c2508ac360cf016c93 will be reverted in a new pull request.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test this PR, I installed Terraform 1.0.7 on my local system and validated the following:
* [x] All pre-commit tests pass locally (note that I had to re-run `terraform init` in both the main and the `examples/basic_usage` directories)
* [x] All GitHub actions pass for this PR
* [x] I was able to successfully `terraform apply` in `examples/basic_usage` without any errors
* [x] I was able to successfully `terraform destroy` all of the resources deployed in the previous step without any errors

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
