### PR TITLE
Add a provider example

### DIFF
--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -41,7 +41,7 @@ Note that this example may create resources which cost money. Run
 | ami\_owner\_account\_id | The ID of the AWS account that owns the AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `"self"` | no |
 | aws\_availability\_zone | The AWS availability zone to deploy into (e.g. a, b, c, etc.). | `string` | `"a"` | no |
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
-| tags | Tags to apply to all AWS resources created. | `map(string)` | `{"Testing": true}` | no |
+| tags | Tags to apply to all AWS resources created. | `map(string)` | ```{ "Testing": true }``` | no |
 | tf\_role\_arn | The ARN of the role that can terraform non-specialized resources. | `string` | n/a | yes |
 
 ## Outputs ##

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,13 @@
+# This is an example of what a provider looks like.
+#
+# provider "aws" {
+#   alias = "myprovider"
+#   assume_role {
+#     role_arn     = "arn:aws:iam::123456789012:role/MyRole"
+#     session_name = "MySessionName"
+#   }
+#   default_tags {
+#     tags = var.tags
+#   }
+#   region = var.aws_region
+# }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a commented-out example of a Terraform provider.

I also took care of a small documentation difference that was missed previously (before our team standardized on using the `--html=false` flag).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Rather than delete the now-unnecessary `providers.tf` file in this skeleton, we felt it would be more educational to include a commented-out example of a provider.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

No testing is needed since I am only adding commented-out informational code.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
