### PR TITLE
Add `terraform-docs` injection headers to example `README.md`

### DIFF
--- a/examples/basic_usage/.terraform-docs.yml
+++ b/examples/basic_usage/.terraform-docs.yml
@@ -1,0 +1,1 @@
+../../.terraform-docs.yml

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -8,6 +8,7 @@ followed by the `terraform apply` command.
 Note that this example may create resources which cost money. Run
 `terraform destroy` when you no longer need these resources.
 
+<!-- BEGIN_TF_DOCS -->
 ## Requirements ##
 
 | Name | Version |
@@ -53,3 +54,4 @@ Note that this example may create resources which cost money. Run
 | id | The EC2 instance ID. |
 | private\_ip | The private IP of the EC2 instance. |
 | subnet\_id | The ID of the subnet where the EC2 instance is deployed. |
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds `terraform-docs` injection headers to the example `README.md` file.
- Symlinks the `.terraform-docs.yml` config file from the root of the repo.

## 💭 Motivation and context ##

Resolves #192, making it easier for us to keep our Terraform documentation in sync with our code changes.

## 🧪 Testing ##

All automated tests pass.  I also ran `terraform-docs` in the `example/basic_usage` directory and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.