### PR TITLE
Specify all variables as non-`nullable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ module "example" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.0 |
+| terraform | ~> 1.1 |
 | aws | ~> 4.9 |
 
 ## Providers ##

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -13,7 +13,7 @@ Note that this example may create resources which cost money. Run
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.0 |
+| terraform | ~> 1.1 |
 | aws | ~> 4.9 |
 
 ## Providers ##

--- a/examples/basic_usage/versions.tf
+++ b/examples/basic_usage/versions.tf
@@ -18,6 +18,7 @@ terraform {
     }
   }
 
-  # We want to hold off on 1.1 or higher until we have tested it.
-  required_version = "~> 1.0"
+  # Version 1.1 of Terraform is the first version to support the
+  # nullable key in variable definitions.
+  required_version = "~> 1.1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@
 
 variable "subnet_id" {
   description = "The ID of the AWS subnet to deploy into (e.g. subnet-0123456789abcdef0)."
+  nullable    = false
   type        = string
 }
 
@@ -17,17 +18,20 @@ variable "subnet_id" {
 variable "ami_owner_account_id" {
   default     = "self"
   description = "The ID of the AWS account that owns the Example AMI, or \"self\" if the AMI is owned by the same account as the provisioner."
+  nullable    = false
   type        = string
 }
 
 variable "aws_availability_zone" {
   default     = "a"
   description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
+  nullable    = false
   type        = string
 }
 
 variable "aws_region" {
   default     = "us-east-1"
   description = "The AWS region to deploy into (e.g. us-east-1)."
+  nullable    = false
   type        = string
 }

--- a/versions.tf
+++ b/versions.tf
@@ -18,6 +18,7 @@ terraform {
     }
   }
 
-  # We want to hold off on 1.1 or higher until we have tested it.
-  required_version = "~> 1.0"
+  # Version 1.1 of Terraform is the first version to support the
+  # nullable key in variable definitions.
+  required_version = "~> 1.1"
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request specifies all variables as non-`nullable`.

## 💭 Motivation and context ##

This means that we need not worry about whether variables are explicitly specified as `null`.  Since this is not something we were expecting, it makes sense to avoid the situation.

See also [the Terraform documentation](https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.