### PR TITLE
Specify all variables in the `basic_usage` example as non-nullable

### DIFF
--- a/examples/basic_usage/variables.tf
+++ b/examples/basic_usage/variables.tf
@@ -6,6 +6,7 @@
 
 variable "tf_role_arn" {
   description = "The ARN of the role that can terraform non-specialized resources."
+  nullable    = false
   type        = string
 }
 
@@ -18,18 +19,21 @@ variable "tf_role_arn" {
 variable "ami_owner_account_id" {
   default     = "self"
   description = "The ID of the AWS account that owns the AMI, or \"self\" if the AMI is owned by the same account as the provisioner."
+  nullable    = false
   type        = string
 }
 
 variable "aws_availability_zone" {
   default     = "a"
   description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
+  nullable    = false
   type        = string
 }
 
 variable "aws_region" {
   default     = "us-east-1"
   description = "The AWS region to deploy into (e.g. us-east-1)."
+  nullable    = false
   type        = string
 }
 
@@ -38,5 +42,6 @@ variable "tags" {
     Testing = true
   }
   description = "Tags to apply to all AWS resources created."
+  nullable    = false
   type        = map(string)
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request makes the variables in the `basic_usage` example root module non-nullable.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This mirrors the change made in #221. If the variables in the `basic_usage` example were _only_ those required by the example module this might not make sense, but since some variables are used separately I believe it makes sense to also make the example's variables non-nullable.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
