### PR TITLE
Use the latest version of the AWS provider for Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ __pycache__
 
 ## Terraform ##
 .terraform
-.terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
 *.tfvars

--- a/examples/basic_usage/.terraform.lock.hcl
+++ b/examples/basic_usage/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.7.0"
+  constraints = ">= 4.9.0, ~> 6.7"
+  hashes = [
+    "h1:MR1e3FM/ZMHBaUOsLJu2XIjkbogmh5q5IV/N73zGX14=",
+    "zh:3c0a256f813e5e2c1e1aa137204ad9168ebe487f6cee874af9e9c78eb300568e",
+    "zh:3c49dd75ea28395b29ba259988826b956c8adf6c0b59dd8874feb4f47bad976a",
+    "zh:3e6e3e3bfc6594f4f9e2c017ee588c5fcad394b87dd0b68a3f37cd66001f3c8c",
+    "zh:3f9b55826eeebf9b2ed448fc111d772c703e1edc6678e1bb646e66f3c3f9308f",
+    "zh:44e4ced936045ddc42d22c653a6427e7eb2b7aee918dff8438da0cb40996beb4",
+    "zh:474ab4d63918f41e8ea1cef43aeb1c719629dbf289db175c95de1431a8853ae7",
+    "zh:71b9e1d82c5ccc8d9bf72b3712c2b90722fc1f35a0f0f7a9557b9ee01971e6e2",
+    "zh:7723256d6ccc55f4000d1df8db202b02b30a7d917f5d31624c717e14ba15ea95",
+    "zh:82174836faa830aff0e47ea61d4cfbb5c97e1e944b1978f1d933acd37f584c88",
+    "zh:8e62fdc10206ba7232eec991e5a387378f2fbe47cc717b7f60eeb1df2c974514",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:be24dd2d53b224d7098e75ca432746e3420ce071189eea100aa8cbcd2498d389",
+    "zh:d27651d0e458933127ddca35a833e1a0f0ff0c131391288b3239763a2fd8f96f",
+    "zh:d33c181fff1b96bf8366e6c3d92408370b21649291e8f4d1f7e9a3fbb920fc9d",
+    "zh:edc0a0a84f85036c6d3df29d09557bd43206d9ee57b10542b484050f0f34d242",
+  ]
+}

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -14,13 +14,13 @@ Note that this example may create resources which cost money. Run
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.1 |
-| aws | ~> 4.9 |
+| aws | ~> 6.7 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 4.9 |
+| aws | ~> 6.7 |
 
 ## Modules ##
 

--- a/examples/basic_usage/versions.tf
+++ b/examples/basic_usage/versions.tf
@@ -3,18 +3,11 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
-    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
-    # only non-breaking changes and deprecation notices are introduced. Using
-    # this version will simplify migration to the new, broken out AWS S3 bucket
-    # configuration resources. Please see
-    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
-    # for more information about the changes in v4.9 and
-    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
-    # for more information about the S3 bucket refactor.
+    # We have verified that our code works with version 6.7 of this
+    # Terraform provider.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.9"
+      version = "~> 6.7"
     }
   }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades to using the latest version of the Terraform AWS provider.  It also commits the `.terraform.lock.hcl` file for more reproducible builds.

## 💭 Motivation and context ##

We should use a modern Terraform AWS provider wherever we can; otherwise, we will get left behind.

Adding the `.terraform.lock.hcl` file is a recommended practice, and it will lead to more reproducible builds.  See [the Terraform documentation](https://developer.hashicorp.com/terraform/language/files/dependency-lock) for more details.

## 🧪 Testing ##

All automated tests pass.

I verified that this version works for this repository by re-running `terraform apply` for the example code.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.